### PR TITLE
ensure handshake done before read

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,9 +144,6 @@ impl TlsConnector {
                 TlsState::Stream
             },
 
-            #[cfg(feature = "early-data")]
-            early_waker: None,
-
             session,
         }))
     }


### PR DESCRIPTION
Sometimes we can not  manually call `flush`,  so we need `auto flush` before read