### PR TITLE
docs: fix examples section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,18 @@ let mut stream = connector.connect(dnsname, stream).await?;
 
 ### Client Example Program
 
-See [examples/client](examples/client/src/main.rs). You can run it with:
+See [examples/client.rs](examples/client.rs). You can run it with:
 
 ```sh
-cd examples/client
-cargo run -- hsts.badssl.com
+cargo run --example client -- hsts.badssl.com
 ```
 
 ### Server Example Program
 
-See [examples/server](examples/server/src/main.rs). You can run it with:
+See [examples/server.rs](examples/server.rs). You can run it with:
 
 ```sh
-cd examples/server
-cargo run -- 127.0.0.1:8000 --cert mycert.der --key mykey.der
+cargo run --example server -- 127.0.0.1:8000 --cert mycert.der --key mykey.der
 ```
 
 ### License & Origin


### PR DESCRIPTION
The links and commands to run the examples were out of date, so I've updated them.

Replaces #5, which doesn't change the commands.