### PR TITLE
Update to rustls 0.22 alpha

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
 tokio = "1.0"
-rustls = { version = "0.21.6", default-features = false }
+rustls = { version = "=0.22.0-alpha.2", default-features = false }
 
 [features]
 default = ["logging", "tls12"]
@@ -29,6 +29,6 @@ argh = "0.1"
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3.1"
 lazy_static = "1"
-webpki-roots = "0.25"
-rustls-pemfile = "1"
-webpki = { package = "rustls-webpki", version = "0.101.2", features = ["alloc", "std"] }
+webpki-roots = "=0.26.0-alpha.1"
+rustls-pemfile = "=2.0.0-alpha.1"
+webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.2", features = ["alloc", "std"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -8,7 +8,6 @@ use std::sync::Arc;
 use argh::FromArgs;
 use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio_rustls::rustls::{self, OwnedTrustAnchor};
 use tokio_rustls::TlsConnector;
 
 /// Tokio Rustls client example
@@ -45,24 +44,11 @@ async fn main() -> io::Result<()> {
     let mut root_cert_store = rustls::RootCertStore::empty();
     if let Some(cafile) = &options.cafile {
         let mut pem = BufReader::new(File::open(cafile)?);
-        let certs = rustls_pemfile::certs(&mut pem)?;
-        let trust_anchors = certs.iter().map(|cert| {
-            let ta = webpki::TrustAnchor::try_from_cert_der(&cert[..]).unwrap();
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        });
-        root_cert_store.add_trust_anchors(trust_anchors);
+        for cert in rustls_pemfile::certs(&mut pem) {
+            root_cert_store.add(cert?).unwrap();
+        }
     } else {
-        root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
+        root_cert_store.add_trust_anchors(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     }
 
     let config = rustls::ClientConfig::builder()

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,9 +1,15 @@
-use super::*;
-use crate::common::IoSession;
+use std::io;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
+use std::pin::Pin;
+use std::task::{Context, Poll};
+
+use rustls::ClientConnection;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::common::{IoSession, Stream, TlsState};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.

--- a/src/common/handshake.rs
+++ b/src/common/handshake.rs
@@ -1,11 +1,13 @@
-use crate::common::{Stream, TlsState};
-use rustls::{ConnectionCommon, SideData};
 use std::future::Future;
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use std::{io, mem};
+
+use rustls::{ConnectionCommon, SideData};
 use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::common::{Stream, TlsState};
 
 pub(crate) trait IoSession {
     type Io;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -1,12 +1,13 @@
-mod handshake;
-
-pub(crate) use handshake::{IoSession, MidHandshake};
-use rustls::{ConnectionCommon, SideData};
 use std::io::{self, IoSlice, Read, Write};
 use std::ops::{Deref, DerefMut};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+use rustls::{ConnectionCommon, SideData};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+mod handshake;
+pub(crate) use handshake::{IoSession, MidHandshake};
 
 #[derive(Debug)]
 pub enum TlsState {

--- a/src/common/test_stream.rs
+++ b/src/common/test_stream.rs
@@ -1,11 +1,13 @@
-use super::Stream;
-use futures_util::future::poll_fn;
-use futures_util::task::noop_waker_ref;
-use rustls::{ClientConnection, Connection, ServerConnection};
 use std::io::{self, Cursor, Read, Write};
 use std::pin::Pin;
 use std::task::{Context, Poll};
+
+use futures_util::future::poll_fn;
+use futures_util::task::noop_waker_ref;
+use rustls::{ClientConnection, Connection, ServerConnection};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
+
+use super::Stream;
 
 struct Good<'a>(&'a mut Connection);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 
 pub use rustls;
+use rustls::crypto::ring::Ring;
 use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 
@@ -67,7 +68,7 @@ pub mod server;
 /// A wrapper around a `rustls::ClientConfig`, providing an async `connect` method.
 #[derive(Clone)]
 pub struct TlsConnector {
-    inner: Arc<ClientConfig>,
+    inner: Arc<ClientConfig<Ring>>,
     #[cfg(feature = "early-data")]
     early_data: bool,
 }
@@ -75,11 +76,11 @@ pub struct TlsConnector {
 /// A wrapper around a `rustls::ServerConfig`, providing an async `accept` method.
 #[derive(Clone)]
 pub struct TlsAcceptor {
-    inner: Arc<ServerConfig>,
+    inner: Arc<ServerConfig<Ring>>,
 }
 
-impl From<Arc<ClientConfig>> for TlsConnector {
-    fn from(inner: Arc<ClientConfig>) -> TlsConnector {
+impl From<Arc<ClientConfig<Ring>>> for TlsConnector {
+    fn from(inner: Arc<ClientConfig<Ring>>) -> TlsConnector {
         TlsConnector {
             inner,
             #[cfg(feature = "early-data")]
@@ -88,8 +89,8 @@ impl From<Arc<ClientConfig>> for TlsConnector {
     }
 }
 
-impl From<Arc<ServerConfig>> for TlsAcceptor {
-    fn from(inner: Arc<ServerConfig>) -> TlsAcceptor {
+impl From<Arc<ServerConfig<Ring>>> for TlsAcceptor {
+    fn from(inner: Arc<ServerConfig<Ring>>) -> TlsAcceptor {
         TlsAcceptor { inner }
     }
 }
@@ -210,9 +211,10 @@ where
     /// # Example
     ///
     /// ```no_run
+    /// # use rustls::crypto::ring::Ring;
     /// # fn choose_server_config(
     /// #     _: rustls::server::ClientHello,
-    /// # ) -> std::sync::Arc<rustls::ServerConfig> {
+    /// # ) -> std::sync::Arc<rustls::ServerConfig<Ring>> {
     /// #     unimplemented!();
     /// # }
     /// # #[allow(unused_variables)]
@@ -304,11 +306,11 @@ where
         self.accepted.client_hello()
     }
 
-    pub fn into_stream(self, config: Arc<ServerConfig>) -> Accept<IO> {
+    pub fn into_stream(self, config: Arc<ServerConfig<Ring>>) -> Accept<IO> {
         self.into_stream_with(config, |_| ())
     }
 
-    pub fn into_stream_with<F>(self, config: Arc<ServerConfig>, f: F) -> Accept<IO>
+    pub fn into_stream_with<F>(self, config: Arc<ServerConfig<Ring>>, f: F) -> Accept<IO>
     where
         F: FnOnce(&mut ServerConnection),
     {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,20 @@
 //!
 //! see <https://github.com/tokio-rs/tls/issues/41>
 
+use std::future::Future;
+use std::io;
+#[cfg(unix)]
+use std::os::unix::io::{AsRawFd, RawFd};
+#[cfg(windows)]
+use std::os::windows::io::{AsRawSocket, RawSocket};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+pub use rustls;
+use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
 macro_rules! ready {
     ( $e:expr ) => {
         match $e {
@@ -47,22 +61,8 @@ macro_rules! ready {
 
 pub mod client;
 mod common;
+use common::{MidHandshake, TlsState};
 pub mod server;
-
-use common::{MidHandshake, Stream, TlsState};
-use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
-use std::future::Future;
-use std::io;
-#[cfg(unix)]
-use std::os::unix::io::{AsRawFd, RawFd};
-#[cfg(windows)]
-use std::os::windows::io::{AsRawSocket, RawSocket};
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
-
-pub use rustls;
 
 /// A wrapper around a `rustls::ClientConfig`, providing an async `connect` method.
 #[derive(Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,15 @@
+use std::io;
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
+use std::pin::Pin;
+use std::task::{Context, Poll};
 
-use super::*;
-use crate::common::IoSession;
+use rustls::ServerConnection;
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::common::{IoSession, Stream, TlsState};
 
 /// A wrapper around an underlying raw stream which implements the TLS or SSL
 /// protocol.

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -2,39 +2,34 @@ mod utils {
     use std::io::{BufReader, Cursor};
     use std::sync::Arc;
 
-    use rustls::{ClientConfig, OwnedTrustAnchor, PrivateKey, RootCertStore, ServerConfig};
+    use rustls::crypto::ring::Ring;
+    use rustls::{ClientConfig, RootCertStore, ServerConfig};
     use rustls_pemfile::{certs, rsa_private_keys};
 
     #[allow(dead_code)]
-    pub fn make_configs() -> (Arc<ServerConfig>, Arc<ClientConfig>) {
+    pub fn make_configs() -> (Arc<ServerConfig<Ring>>, Arc<ClientConfig<Ring>>) {
         const CERT: &str = include_str!("end.cert");
         const CHAIN: &str = include_str!("end.chain");
         const RSA: &str = include_str!("end.rsa");
 
         let cert = certs(&mut BufReader::new(Cursor::new(CERT)))
-            .unwrap()
-            .drain(..)
-            .map(rustls::Certificate)
+            .map(|result| result.unwrap())
             .collect();
-        let mut keys = rsa_private_keys(&mut BufReader::new(Cursor::new(RSA))).unwrap();
-        let mut keys = keys.drain(..).map(PrivateKey);
+        let key = rsa_private_keys(&mut BufReader::new(Cursor::new(RSA)))
+            .next()
+            .unwrap()
+            .unwrap();
         let sconfig = ServerConfig::builder()
             .with_safe_defaults()
             .with_no_client_auth()
-            .with_single_cert(cert, keys.next().unwrap())
+            .with_single_cert(cert, key.into())
             .unwrap();
 
         let mut client_root_cert_store = RootCertStore::empty();
         let mut chain = BufReader::new(Cursor::new(CHAIN));
-        let certs = certs(&mut chain).unwrap();
-        client_root_cert_store.add_trust_anchors(certs.iter().map(|cert| {
-            let ta = webpki::TrustAnchor::try_from_cert_der(&cert[..]).unwrap();
-            OwnedTrustAnchor::from_subject_spki_name_constraints(
-                ta.subject,
-                ta.spki,
-                ta.name_constraints,
-            )
-        }));
+        for cert in certs(&mut chain) {
+            client_root_cert_store.add(cert.unwrap()).unwrap();
+        }
 
         let cconfig = ClientConfig::builder()
             .with_safe_defaults()


### PR DESCRIPTION
For now, sticking with the default `Ring` `CryptoProvider`, since it will likely disappear become a trait object that doesn't appear in public types.