### PR TITLE
Fix minimal dependency versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ secret_extraction = ["rustls/secret_extraction"]
 tls12 = ["rustls/tls12"]
 
 [dev-dependencies]
-argh = "0.1"
+argh = "0.1.1"
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3.1"
-lazy_static = "1"
+lazy_static = "1.1"
 webpki-roots = "=0.26.0-alpha.1"
 rustls-pemfile = "=2.0.0-alpha.1"
 webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.2", features = ["alloc", "std"] }


### PR DESCRIPTION
While investing something else in nats.rs library, after running

```
cargo +nightly update -Zminimal-versions
cargo check  --all-targets
```
I found some errors in this repo minimum versions. 
This bumps them to the required minimum.

Signed-off-by: Tomasz Pietrek <melgaer@gmail.com>