### PR TITLE
Replace futures_util::pin_mut with tokio::pin in doc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ where
     /// let (stream, _) = listener.accept().await.unwrap();
     ///
     /// let acceptor = tokio_rustls::LazyConfigAcceptor::new(rustls::server::Acceptor::default(), stream);
-    /// futures_util::pin_mut!(acceptor);
+    /// tokio::pin!(acceptor);
     ///
     /// match acceptor.as_mut().await {
     ///     Ok(start) => {


### PR DESCRIPTION
As `tokio-rustls` is a crate for collaborating `tokio` and `rustls`, it might be more simple to use `tokio::pin` than `futures_util::pin_mut` in the document.