### PR TITLE
Prepare 0.25 release, update to Rustls 0.22

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 Cargo.lock
 .DS_Store
+/.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.25.0-alpha.4"
+version = "0.25.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustls/tokio-rustls"
 homepage = "https://github.com/rustls/tokio-rustls"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
 tokio = "1.0"
-rustls = { version = "=0.22.0-alpha.6", default-features = false }
-pki-types = { package = "rustls-pki-types", version = "0.2.2" }
+rustls = { version = "0.22", default-features = false }
+pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]
 default = ["logging", "tls12", "ring"]
@@ -29,6 +29,6 @@ argh = "0.1.1"
 tokio = { version = "1.0", features = ["full"] }
 futures-util = "0.3.1"
 lazy_static = "1.1"
-webpki-roots = "=0.26.0-alpha.2"
-rustls-pemfile = "=2.0.0-alpha.2"
-webpki = { package = "rustls-webpki", version = "=0.102.0-alpha.8", features = ["alloc", "std"] }
+webpki-roots = "0.26"
+rustls-pemfile = "2"
+webpki = { package = "rustls-webpki", version = "0.102", features = ["alloc", "std"] }

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -52,7 +52,6 @@ async fn main() -> io::Result<()> {
     }
 
     let config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_cert_store)
         .with_no_client_auth(); // i guess this was previously the default?
     let connector = TlsConnector::from(Arc::new(config));

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -56,7 +56,6 @@ async fn main() -> io::Result<()> {
     let flag_echo = options.echo_mode;
 
     let config = rustls::ServerConfig::builder()
-        .with_safe_defaults()
         .with_no_client_auth()
         .with_single_cert(certs, key)
         .map_err(|err| io::Error::new(io::ErrorKind::InvalidInput, err))?;

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -35,11 +35,7 @@ async fn get(
 async fn test_tls12() -> io::Result<()> {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
-    let config = rustls::ClientConfig::builder()
-        .with_safe_default_cipher_suites()
-        .with_safe_default_kx_groups()
-        .with_protocol_versions(&[&rustls::version::TLS12])
-        .unwrap()
+    let config = rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS12])
         .with_root_certificates(root_store)
         .with_no_client_auth();
 
@@ -68,7 +64,6 @@ async fn test_modern() -> io::Result<()> {
     let mut root_store = rustls::RootCertStore::empty();
     root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
     let config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let config = Arc::new(config);

--- a/tests/early-data.rs
+++ b/tests/early-data.rs
@@ -133,13 +133,10 @@ async fn test_0rtt() -> io::Result<()> {
         root_store.add(cert.unwrap()).unwrap();
     }
 
-    let mut config = rustls::ClientConfig::builder()
-        .with_safe_default_cipher_suites()
-        .with_safe_default_kx_groups()
-        .with_protocol_versions(&[&rustls::version::TLS13])
-        .unwrap()
-        .with_root_certificates(root_store)
-        .with_no_client_auth();
+    let mut config =
+        rustls::ClientConfig::builder_with_protocol_versions(&[&rustls::version::TLS13])
+            .with_root_certificates(root_store)
+            .with_no_client_auth();
     config.enable_early_data = true;
     let config = Arc::new(config);
     let addr = SocketAddr::from(([127, 0, 0, 1], server_port));

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -30,7 +30,6 @@ lazy_static! {
             .unwrap();
 
         let config = rustls::ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(cert, key.into())
             .unwrap();
@@ -117,7 +116,6 @@ async fn pass() -> io::Result<()> {
     }
 
     let config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let config = Arc::new(config);
@@ -137,7 +135,6 @@ async fn fail() -> io::Result<()> {
     }
 
     let config = rustls::ClientConfig::builder()
-        .with_safe_defaults()
         .with_root_certificates(root_store)
         .with_no_client_auth();
     let config = Arc::new(config);

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -19,7 +19,6 @@ mod utils {
             .unwrap()
             .unwrap();
         let sconfig = ServerConfig::builder()
-            .with_safe_defaults()
             .with_no_client_auth()
             .with_single_cert(cert, key.into())
             .unwrap();
@@ -31,7 +30,6 @@ mod utils {
         }
 
         let cconfig = ClientConfig::builder()
-            .with_safe_defaults()
             .with_root_certificates(client_root_cert_store)
             .with_no_client_auth();
 


### PR DESCRIPTION
This branch updates to rustls 0.22 and bumps the crate version from 0.25.0-alpha.4 to 0.25, taking the following associated updates:

* rustls 0.22.0-alpha-4 -> 0.22
* pki-types 0.2.2 -> 1
* webpki-roots 0.26.0-alpha.2 -> 0.26
* rustls-pemfile 2.0.0-alpha.2 -> 2
* webpki 0.102.0-alpha.8 -> 0.102

Breaking API changes are addressed as required.
