### PR TITLE
Avoid sending empty root hints list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
 tokio = "1.0"
-rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe" }
+rustls = { git = "https://github.com/fortanix/rustls", rev = "1f9441aba2fe859e98084c164bacc334a5140689" }
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
 tokio = "1.0"
-rustls = { version = "0.22", default-features = false }
+rustls = { git = "https://github.com/fortanix/rustls", tag = "ffdhe" }
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]


### PR DESCRIPTION
This PR need to wait for https://github.com/fortanix/rustls/pull/5 to be merged.

Then update the rustls to use new tag again.