### PR TITLE
feat: add fips pass-through feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ pki-types = { package = "rustls-pki-types", version = "1" }
 default = ["logging", "tls12", "ring"]
 aws-lc-rs = ["rustls/aws_lc_rs"]
 early-data = []
+fips = ["rustls/fips"]
 logging = ["rustls/logging"]
 ring = ["rustls/ring"]
 tls12 = ["rustls/tls12"]


### PR DESCRIPTION
This avoids people having to add `rustls` directly to their Cargo.toml just to enable a feature.