### PR TITLE
feat: change default crypto provider to match rustls'

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,6 +44,15 @@ jobs:
         with:
           toolchain: ${{ matrix.rust }}
 
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v4
+
+
       - name: Test
         run: |
           cargo test --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rustls = { version = "0.23", default-features = false, features = ["std"] }
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]
-default = ["logging", "tls12", "ring"]
+default = ["logging", "tls12", "aws-lc-rs"]
 aws-lc-rs = ["rustls/aws_lc_rs"]
 early-data = []
 logging = ["rustls/logging"]


### PR DESCRIPTION
It would be confusing for rustls docs to say "by default it uses [aws-lc-rs](https://crates.io/crates/aws-lc-rs) for implementing the cryptography in TLS" but discover that tokio-rustls changes the default.