### PR TITLE
Cargo: 0.25.0 -> 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 license = "MIT/Apache-2.0"
 repository = "https://github.com/rustls/tokio-rustls"
 homepage = "https://github.com/rustls/tokio-rustls"


### PR DESCRIPTION
Preparation to cut a new 0.26.0 release to bring in [changes since 0.25](https://github.com/rustls/tokio-rustls/compare/534344388ecc6634a133bd619c49170a79e38dc8..56653423810ff032a9505b6902e0ac1d6927e448).

This repo doesn't have an established CHANGELOG or GitHub releases, but the major callouts I would include would be:

## Additions
* Support for Rustls 0.23 and the new acceptor alert API - by @ctz in #44
* Support for aws-lc-rs as the new default crypto backend, allowing passthrough of the `fips` feature - by @BiagioFesta in #43, @jbr in #49, #50
* Support for forwarding vectored writes - by @paolobarbolini in #45

## Fixes
* Ignoring `NotConnected` error in `poll_shutdown` - by @djc in #42
* Check for `ErrorKind::WouldBlock` in `MidHandshake::SendAlert` poll - by @jbr in #47
* Check for `ErrorKind::WouldBlock` in `LayzConfigAcceptor` - by @jbr in #48
* Fix for `SendAlert` `io::ErrorKind` - by @jbr in #52
* Fix for `alert.write` poll - by @jbr in #51
