### PR TITLE
Read any pending data before shutting down stream

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -339,6 +339,10 @@ where
             ready!(self.write_io(cx))?;
         }
 
+        while self.session.wants_read() {
+            ready!(self.read_io(cx))?;
+        }
+
         Poll::Ready(match ready!(Pin::new(&mut self.io).poll_shutdown(cx)) {
             Ok(()) => Ok(()),
             // When trying to shutdown, not being connected seems fine


### PR DESCRIPTION
I ran into the issue where another Rustls client (`launchbadge/sqlx`) is sending CloseNotify (correctly I believe) before shutting down the stream. If the server doesn't wait for it when shutting down the socket, the client throws:

```
Transport endpoint is not connected (os error 107)
```

This PR ensures if there are any data still in the stream, it's read in and only then the stream is closed. All incoming data at this point is discarded, so this [shouldn't be security issue](https://security.stackexchange.com/a/82034) I think, but I'm not an expert.