### PR TITLE
Fix test regression after rustls improvements in complete_io()

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -98,7 +98,7 @@ where
             Err(err) => return Poll::Ready(Err(err)),
         };
 
-        let stats = self.session.process_new_packets().map_err(|err| {
+        self.session.process_new_packets().map_err(|err| {
             // In case we have an alert to send describing this error,
             // try a last-gasp write -- but don't predate the primary
             // error.
@@ -106,13 +106,6 @@ where
 
             io::Error::new(io::ErrorKind::InvalidData, err)
         })?;
-
-        if stats.peer_has_closed() && self.session.is_handshaking() {
-            return Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::UnexpectedEof,
-                "tls handshake alert",
-            )));
-        }
 
         Poll::Ready(Ok(n))
     }

--- a/src/common/test_stream.rs
+++ b/src/common/test_stream.rs
@@ -264,7 +264,7 @@ async fn stream_handshake_regression_issues_77() -> io::Result<()> {
     let r = stream.handshake(&mut cx);
     assert_eq!(
         r.map_err(|err| err.kind()),
-        Poll::Ready(Err(io::ErrorKind::UnexpectedEof))
+        Poll::Ready(Err(io::ErrorKind::InvalidData))
     );
 
     Ok(()) as io::Result<()>


### PR DESCRIPTION
A weekly CI run noticed a change from `io::Error::UnexpectedEof` to `InvalidData` today in a [test](https://github.com/rustls/tokio-rustls/blob/main/src/common/test_stream.rs#L257) for https://github.com/tokio-rs/tls/issues/77 (that should likely have triggered me to follow-up directly in rustls itself back in the day...), which was fixed in https://github.com/tokio-rs/tls/pull/78. I also added a commit to remove the extra logic which now appears to be unnecessary.

It makes sense to me that `InvalidData` is probably a better error for this than `UnexpectedEof`.

Fixes #67.