### PR TITLE
Add async way to read early data from TLSAcceptor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ exclude = ["/.github", "/examples", "/scripts"]
 [dependencies]
 tokio = "1.0"
 rustls = { version = "0.23.5", default-features = false, features = ["std"] }
+pin-project-lite = "0.2.14"
 pki-types = { package = "rustls-pki-types", version = "1" }
 
 [features]


### PR DESCRIPTION
Enables reading early data server-side in an async way, separate from the normal reading method.

Please give any suggestions 🙂