### PR TITLE
release 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 dependencies = [
  "argh",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tokio-rustls"
-version = "0.26.0"
+version = "0.26.1"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustls/tokio-rustls"
 homepage = "https://github.com/rustls/tokio-rustls"


### PR DESCRIPTION
We seem to have [updated MSRV](https://github.com/rustls/tokio-rustls/commit/409d8742efd3f2b2976623edfe80e0b5dc57769f), I'm not sure about our MSRV policy, do we need to release 0.27.0? cc @djc 