### PR TITLE
feat: add support for processing handshake packets async via compute-heavy-future-executor

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           cargo test --locked --all
           cargo test --locked -p tokio-rustls --features early-data --test early-data
+          # we run all test suites against this feature since it shifts the default behavior globally
+          cargo test --locked -p tokio-rustls --features compute-heavy-future-executor
 
   lints:
     name: Lints

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,6 +208,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "compute-heavy-future-executor"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -443,6 +452,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
+name = "num_cpus"
+version = "1.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "object"
 version = "0.36.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,9 +517,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
@@ -809,8 +828,10 @@ name = "tokio-rustls"
 version = "0.26.1"
 dependencies = [
  "argh",
+ "compute-heavy-future-executor",
  "futures-util",
  "lazy_static",
+ "pin-project-lite",
  "rcgen",
  "rustls",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,10 @@ rust-version = "1.70"
 exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
+# implicitly enables the tokio feature for compute-heavy-future-executor
+# (defaulting to strategy of spawn_blocking w/ concurrency conctorl)
+compute-heavy-future-executor = { version = "0.1", optional = true}
+pin-project-lite = { version = "0.2.15", optional = true }
 rustls = { version = "0.23.15", default-features = false, features = ["std"] }
 tokio = "1.0"
 
@@ -20,6 +24,7 @@ tokio = "1.0"
 default = ["logging", "tls12", "aws_lc_rs"]
 aws_lc_rs = ["rustls/aws_lc_rs"]
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
+compute-heavy-future-executor = ["dep:compute-heavy-future-executor", "pin-project-lite"]
 early-data = []
 fips = ["rustls/fips"]
 logging = ["rustls/logging"]
@@ -33,3 +38,6 @@ lazy_static = "1.1"
 rcgen = { version = "0.13", features = ["pem"] }
 tokio = { version = "1.0", features = ["full"] }
 webpki-roots = "0.26"
+
+[patch.crates-io]
+compute-heavy-future-executor = { path = "../compute-heavy-future-executor" }

--- a/src/common/async_session.rs
+++ b/src/common/async_session.rs
@@ -1,0 +1,128 @@
+use std::{
+    future::Future,
+    io,
+    ops::{Deref, DerefMut},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+use pin_project_lite::pin_project;
+use rustls::{ConnectionCommon, SideData};
+use tokio::io::{AsyncRead, AsyncWrite};
+
+use crate::common::IoSession;
+
+use super::{Stream, TlsState};
+
+/// Full result of sync closure
+type SessionResult<S> = Result<S, (Option<S>, io::Error)>;
+/// Executor result wrapping sync closure result
+type SyncExecutorResult<S> = Result<SessionResult<S>, compute_heavy_future_executor::Error>;
+/// Future wrapping waiting on executor
+type SessionFuture<S> = Box<dyn Future<Output = SyncExecutorResult<S>> + Unpin + Send>;
+
+pin_project! {
+/// Session is off doing compute-heavy sync work, such as initializing the session or processing handshake packets.
+/// Might be on another thread / external threadpool.
+///
+/// This future sleeps on it in current worker thread until it completes.
+pub(crate) struct AsyncSession<IS: IoSession> {
+    #[pin]
+    future: SessionFuture<IS::Session>,
+    io: IS::Io,
+    state: TlsState,
+    extras: IS::Extras,
+}
+}
+
+impl<IS, SD> AsyncSession<IS>
+where
+    IS: IoSession + Unpin,
+    IS::Io: AsyncRead + AsyncWrite + Unpin,
+    IS::Session: DerefMut + Deref<Target = ConnectionCommon<SD>> + Unpin + Send + 'static,
+    SD: SideData,
+{
+    pub(crate) fn process_packets(stream: IS) -> Self {
+        let (state, io, mut session, extras) = stream.into_inner();
+
+        let closure = move || match session.process_new_packets() {
+            Ok(_) => Ok(session),
+            Err(err) => Err((
+                Some(session),
+                io::Error::new(io::ErrorKind::InvalidData, err),
+            )),
+        };
+
+        let future = compute_heavy_future_executor::execute_sync(closure);
+
+        Self {
+            future: Box::new(Box::pin(future)),
+            io,
+            state,
+            extras,
+        }
+    }
+
+    pub(crate) fn into_stream(
+        mut self,
+        session_result: Result<IS::Session, (Option<IS::Session>, io::Error)>,
+        cx: &mut Context<'_>,
+    ) -> Result<IS, (io::Error, IS::Io)> {
+        match session_result {
+            Ok(session) => Ok(IS::from_inner(self.state, self.io, session, self.extras)),
+            Err((Some(mut session), err)) => {
+                // In case we have an alert to send describing this error,
+                // try a last-gasp write -- but don't predate the primary
+                // error.
+                let mut tls_stream: Stream<'_, <IS as IoSession>::Io, <IS as IoSession>::Session> =
+                    Stream::new(&mut self.io, &mut session).set_eof(!self.state.readable());
+                let _ = tls_stream.write_io(cx);
+
+                // still drop the tls session and return the io error only
+                Err((err, self.io))
+            }
+            Err((None, err)) => Err((err, self.io)),
+        }
+    }
+
+    #[inline]
+    pub fn get_ref(&self) -> &IS::Io {
+        &self.io
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> &mut IS::Io {
+        &mut self.io
+    }
+}
+
+impl<IS, SD> Future for AsyncSession<IS>
+where
+    IS: IoSession + Unpin,
+    IS::Session: DerefMut + Deref<Target = ConnectionCommon<SD>> + Unpin + Send + 'static,
+    SD: SideData,
+{
+    type Output = Result<IS::Session, (Option<IS::Session>, io::Error)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut this = self.project();
+
+        match ready!(this.future.as_mut().poll(cx)) {
+            Ok(session_res) => match session_res {
+                Ok(res) => Poll::Ready(Ok(res)),
+                // return any session along with the error,
+                // so the caller can flush any remaining alerts in buffer to i/o
+                Err((session, err)) => Poll::Ready(Err((
+                    session,
+                    io::Error::new(io::ErrorKind::InvalidData, err),
+                ))),
+            },
+            // We don't have a session to flush here because the executor ate it
+            // TODO: not all errors should be modeled as io
+            Err(executor_error) => Poll::Ready(Err((
+                None,
+                io::Error::new(io::ErrorKind::Other, executor_error),
+            ))),
+        }
+    }
+}

--- a/src/common/handshake.rs
+++ b/src/common/handshake.rs
@@ -10,17 +10,32 @@ use tokio::io::{AsyncRead, AsyncWrite};
 
 use crate::common::{Stream, SyncWriteAdapter, TlsState};
 
+#[cfg(feature = "compute-heavy-future-executor")]
+use super::async_session::AsyncSession;
+
 pub(crate) trait IoSession {
     type Io;
     type Session;
+    type Extras;
 
     fn skip_handshake(&self) -> bool;
     fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session);
     fn into_io(self) -> Self::Io;
+    #[allow(dead_code)]
+    fn into_inner(self) -> (TlsState, Self::Io, Self::Session, Self::Extras);
+    #[allow(dead_code)]
+    fn from_inner(
+        state: TlsState,
+        io: Self::Io,
+        session: Self::Session,
+        extras: Self::Extras,
+    ) -> Self;
 }
 
 pub(crate) enum MidHandshake<IS: IoSession> {
     Handshaking(IS),
+    #[cfg(feature = "compute-heavy-future-executor")]
+    AsyncSession(AsyncSession<IS>),
     End,
     SendAlert {
         io: IS::Io,
@@ -32,12 +47,11 @@ pub(crate) enum MidHandshake<IS: IoSession> {
         error: io::Error,
     },
 }
-
 impl<IS, SD> Future for MidHandshake<IS>
 where
     IS: IoSession + Unpin,
     IS::Io: AsyncRead + AsyncWrite + Unpin,
-    IS::Session: DerefMut + Deref<Target = ConnectionCommon<SD>> + Unpin,
+    IS::Session: DerefMut + Deref<Target = ConnectionCommon<SD>> + Unpin + Send + 'static,
     SD: SideData,
 {
     type Output = Result<IS, (io::Error, IS::Io)>;
@@ -47,6 +61,12 @@ where
 
         let mut stream = match mem::replace(this, MidHandshake::End) {
             MidHandshake::Handshaking(stream) => stream,
+            #[cfg(feature = "compute-heavy-future-executor")]
+            MidHandshake::AsyncSession(mut async_session) => {
+                let pinned = Pin::new(&mut async_session);
+                let session_result = ready!(pinned.poll(cx));
+                async_session.into_stream(session_result, cx)?
+            }
             MidHandshake::SendAlert {
                 mut io,
                 mut alert,
@@ -74,6 +94,35 @@ where
                 ( $e:expr ) => {
                     match $e {
                         Poll::Ready(Ok(_)) => (),
+                        #[cfg(feature = "compute-heavy-future-executor")]
+                        Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::WouldBlock => {
+                            // TODO: downcast to decide on closure, for now we only do this for
+                            // process_packets
+
+                            // decompose the stream and send the session to background executor
+                            let mut async_session = AsyncSession::process_packets(stream);
+
+                            let pinned = Pin::new(&mut async_session);
+                            // poll once to kick off work
+                            match pinned.poll(cx) {
+                                // didn't need to sleep for async session
+                                Poll::Ready(res) => {
+                                    let stream = async_session.into_stream(res, cx)?;
+                                    // rather than continuing processing here,
+                                    // we keep memory  management simple and recompose
+                                    // our future for a fresh poll
+                                    *this = MidHandshake::Handshaking(stream);
+                                    // tell executor to immediately poll us again
+                                    cx.waker().wake_by_ref();
+                                    return Poll::Pending;
+                                }
+                                // task is sleeping until async session is complete
+                                Poll::Pending => {
+                                    *this = MidHandshake::AsyncSession(async_session);
+                                    return Poll::Pending;
+                                }
+                            }
+                        }
                         Poll::Ready(Err(err)) => return Poll::Ready(Err((err, stream.into_io()))),
                         Poll::Pending => {
                             *this = MidHandshake::Handshaking(stream);
@@ -83,8 +132,12 @@ where
                 };
             }
 
+
             while tls_stream.session.is_handshaking() {
-                try_poll!(tls_stream.handshake(cx));
+                #[cfg(feature = "compute-heavy-future-executor")]
+                try_poll!(tls_stream.handshake(cx, true));
+                #[cfg(not(feature = "compute-heavy-future-executor"))]
+                try_poll!(tls_stream.handshake(cx, false));
             }
 
             try_poll!(Pin::new(&mut tls_stream).poll_flush(cx));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -369,7 +369,10 @@ pub struct FallibleConnect<IO>(MidHandshake<client::TlsStream<IO>>);
 /// Like [Accept], but returns `IO` on failure.
 pub struct FallibleAccept<IO>(MidHandshake<server::TlsStream<IO>>);
 
-impl<IO> Connect<IO> {
+impl<IO> Connect<IO>
+where
+    IO: Unpin + AsyncRead + AsyncWrite,
+{
     #[inline]
     pub fn into_fallible(self) -> FallibleConnect<IO> {
         FallibleConnect(self.0)
@@ -378,6 +381,8 @@ impl<IO> Connect<IO> {
     pub fn get_ref(&self) -> Option<&IO> {
         match &self.0 {
             MidHandshake::Handshaking(sess) => Some(sess.get_ref().0),
+            #[cfg(feature = "compute-heavy-future-executor")]
+            MidHandshake::AsyncSession(sess) => Some(sess.get_ref()),
             MidHandshake::SendAlert { io, .. } => Some(io),
             MidHandshake::Error { io, .. } => Some(io),
             MidHandshake::End => None,
@@ -387,6 +392,8 @@ impl<IO> Connect<IO> {
     pub fn get_mut(&mut self) -> Option<&mut IO> {
         match &mut self.0 {
             MidHandshake::Handshaking(sess) => Some(sess.get_mut().0),
+            #[cfg(feature = "compute-heavy-future-executor")]
+            MidHandshake::AsyncSession(sess) => Some(sess.get_mut()),
             MidHandshake::SendAlert { io, .. } => Some(io),
             MidHandshake::Error { io, .. } => Some(io),
             MidHandshake::End => None,
@@ -394,7 +401,10 @@ impl<IO> Connect<IO> {
     }
 }
 
-impl<IO> Accept<IO> {
+impl<IO> Accept<IO>
+where
+    IO: Unpin + AsyncRead + AsyncWrite,
+{
     #[inline]
     pub fn into_fallible(self) -> FallibleAccept<IO> {
         FallibleAccept(self.0)
@@ -403,6 +413,8 @@ impl<IO> Accept<IO> {
     pub fn get_ref(&self) -> Option<&IO> {
         match &self.0 {
             MidHandshake::Handshaking(sess) => Some(sess.get_ref().0),
+            #[cfg(feature = "compute-heavy-future-executor")]
+            MidHandshake::AsyncSession(sess) => Some(sess.get_ref()),
             MidHandshake::SendAlert { io, .. } => Some(io),
             MidHandshake::Error { io, .. } => Some(io),
             MidHandshake::End => None,
@@ -412,6 +424,8 @@ impl<IO> Accept<IO> {
     pub fn get_mut(&mut self) -> Option<&mut IO> {
         match &mut self.0 {
             MidHandshake::Handshaking(sess) => Some(sess.get_mut().0),
+            #[cfg(feature = "compute-heavy-future-executor")]
+            MidHandshake::AsyncSession(sess) => Some(sess.get_mut()),
             MidHandshake::SendAlert { io, .. } => Some(io),
             MidHandshake::Error { io, .. } => Some(io),
             MidHandshake::End => None,

--- a/src/server.rs
+++ b/src/server.rs
@@ -40,6 +40,7 @@ impl<IO> TlsStream<IO> {
 impl<IO> IoSession for TlsStream<IO> {
     type Io = IO;
     type Session = ServerConnection;
+    type Extras = ();
 
     #[inline]
     fn skip_handshake(&self) -> bool {
@@ -54,6 +55,20 @@ impl<IO> IoSession for TlsStream<IO> {
     #[inline]
     fn into_io(self) -> Self::Io {
         self.io
+    }
+
+    #[inline]
+    fn into_inner(self) -> (TlsState, Self::Io, Self::Session, Self::Extras) {
+        (self.state, self.io, self.session, ())
+    }
+
+    fn from_inner(
+        state: TlsState,
+        io: Self::Io,
+        session: Self::Session,
+        _extras: Self::Extras,
+    ) -> Self {
+        Self { io, session, state }
     }
 }
 

--- a/tests/async_session.rs
+++ b/tests/async_session.rs
@@ -1,0 +1,149 @@
+#![cfg(feature = "compute-heavy-future-executor")]
+//! Using the `compute-heavy-future-executor` feature shifts the global behavior
+//! of processing bytes + establishing handshakes. So all other test suites running are validating
+//! parity of processing.
+//!
+//! This suite in particular is probing that the async executor futures are actually doing anything + that executor
+//! failures are handled properly.
+
+use std::io::{self, ErrorKind, Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::thread;
+
+use compute_heavy_future_executor::{global_sync_strategy_builder, CustomExecutorSyncClosure};
+use futures_util::{future::Future, ready};
+use rustls::pki_types::ServerName;
+use rustls::{self, ClientConfig, ServerConnection, Stream};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
+use tokio::net::TcpStream;
+use tokio_rustls::{client::TlsStream, TlsConnector};
+
+struct Read1<T>(T);
+
+impl<T: AsyncRead + Unpin> Future for Read1<T> {
+    type Output = io::Result<()>;
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let mut buf = [0];
+        let mut buf = ReadBuf::new(&mut buf);
+
+        ready!(Pin::new(&mut self.0).poll_read(cx, &mut buf))?;
+
+        if buf.filled().is_empty() {
+            Poll::Ready(Ok(()))
+        } else {
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        }
+    }
+}
+
+/// returns rx to listen on to confirm layer was hit
+fn async_session_executor() -> (tokio::sync::mpsc::Receiver<()>, Arc<AtomicBool>) {
+    let (result_tx, result_rx) = tokio::sync::mpsc::channel(10);
+    let fail = Arc::new(AtomicBool::new(false));
+
+    let fail_cloned = fail.clone();
+    let closure: CustomExecutorSyncClosure = Box::new(move |f| {
+        let tx = result_tx.clone();
+        let fail = fail_cloned.clone();
+
+        Box::new(async move {
+            if fail.load(Ordering::Relaxed) {
+                return Err(Box::from("executor failed"));
+            }
+            let _ = tx.send(()).await;
+            Ok(tokio::task::spawn_blocking(move || f()).await.unwrap())
+        })
+    });
+
+    global_sync_strategy_builder()
+        .initialize_custom_executor(closure)
+        .unwrap();
+
+    (result_rx, fail)
+}
+
+#[tokio::test]
+async fn test_async_session() {
+    let (mut res_rx, fail) = async_session_executor();
+
+    let _ = async_session_impl().await;
+
+    let res = res_rx.recv().await;
+    assert!(res.is_some(), "async session executor did not fire");
+
+    // make the async executor fail further calls
+    fail.store(true, Ordering::Relaxed);
+
+    let res = async_session_impl().await;
+    assert!(
+        res.is_err_and(|err| err.kind() == ErrorKind::Other),
+        "async session executor did not return proper error"
+    );
+}
+
+async fn send(
+    config: Arc<ClientConfig>,
+    addr: SocketAddr,
+    data: &[u8],
+    vectored: bool,
+) -> io::Result<(TlsStream<TcpStream>, Vec<u8>)> {
+    let connector = TlsConnector::from(config);
+    let stream = TcpStream::connect(&addr).await?;
+    let domain = ServerName::try_from("foobar.com").unwrap();
+
+    let mut stream = connector.connect(domain, stream).await?;
+    utils::write(&mut stream, data, vectored).await?;
+    stream.flush().await?;
+    stream.shutdown().await?;
+
+    let mut buf = Vec::new();
+    stream.read_to_end(&mut buf).await?;
+
+    Ok((stream, buf))
+}
+
+async fn async_session_impl() -> io::Result<()> {
+    let (server, client) = utils::make_configs();
+    let server = Arc::new(server);
+
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let server_port = listener.local_addr().unwrap().port();
+    thread::spawn(move || loop {
+        let (mut sock, _addr) = listener.accept().unwrap();
+
+        let server = Arc::clone(&server);
+        thread::spawn(move || {
+            let mut conn = ServerConnection::new(server).unwrap();
+            conn.complete_io(&mut sock).unwrap();
+
+            let mut stream = Stream::new(&mut conn, &mut sock);
+            stream.write_all(b"FOO:").unwrap();
+            loop {
+                let mut buf = [0; 1024];
+                let n = stream.read(&mut buf).unwrap();
+                if n == 0 {
+                    conn.send_close_notify();
+                    conn.complete_io(&mut sock).unwrap();
+                    break;
+                }
+                stream.write_all(&buf[..n]).unwrap();
+            }
+        });
+    });
+
+    let client = Arc::new(client);
+    let addr = SocketAddr::from(([127, 0, 0, 1], server_port));
+
+    let _ = send(client.clone(), addr, b"hello", false).await?;
+
+    Ok(())
+}
+
+// Include `utils` module
+include!("utils.rs");


### PR DESCRIPTION
WIP, I plan to add:
- optional async handling for client/server instantiation too, as that was also blocking in my profiling
- probably try to clean up error modeling a bit

Staging this now to demonstrate what it would be like to use https://github.com/jlizen/compute-heavy-future-executor/pull/9 in practice. Also for early feedback from team (or `tokio-rustls` maintainers if you have time, no rush though, I'll cut an official PR after it's polished).