### PR TITLE
Implement AsyncBufRead

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,36 +65,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.12.12"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4795bbabc13643a8b3532184041ab41dec5740046aa15734428219cb9a0bfc"
-dependencies = [
- "bindgen",
- "cmake",
- "dunce",
- "fs_extra",
- "libc",
- "paste",
-]
-
-[[package]]
-name = "aws-lc-rs"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd82dba44d209fddb11c190e0a94b78651f95299598e472215667417a03ff1d"
-dependencies = [
- "aws-lc-fips-sys",
- "aws-lc-sys",
- "mirai-annotations",
- "paste",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df7a4168111d7eb622a31b214057b8509c0a7e1794f44c546d742330dc793972"
+checksum = "59057b878509d88952425fe694a2806e468612bde2d71943f3cd8034935b5032"
 dependencies = [
  "bindgen",
  "cc",
@@ -102,6 +75,33 @@ dependencies = [
  "dunce",
  "fs_extra",
  "libc",
+ "paste",
+ "regex",
+]
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f409eb70b561706bf8abba8ca9c112729c481595893fd06a2dd9af8ed8441148"
+dependencies = [
+ "aws-lc-fips-sys",
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923ded50f602b3007e5e63e3f094c479d9c8a9b42d7f4034e4afe456aa48bfd2"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
  "paste",
 ]
 
@@ -421,12 +421,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mirai-annotations"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
-
-[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -635,9 +629,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.15"
+version = "0.23.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fbb44d7acc4e873d613422379f69f237a1b141928c02f6bc6ccfddddc2d7993"
+checksum = "9fb9263ab4eb695e42321db096e3b8fbd715a59b154d5c88d82db2175b681ba7"
 dependencies = [
  "aws-lc-rs",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ rust-version = "1.71"
 exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
-rustls = { version = "0.23.15", default-features = false, features = ["std"] }
+rustls = { version = "0.23.22", default-features = false, features = ["std"] }
 tokio = "1.0"
 
 [features]

--- a/src/server.rs
+++ b/src/server.rs
@@ -62,37 +62,15 @@ where
     IO: AsyncRead + AsyncWrite + Unpin,
 {
     fn poll_read(
-        self: Pin<&mut Self>,
+        mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
         buf: &mut ReadBuf<'_>,
     ) -> Poll<io::Result<()>> {
-        let this = self.get_mut();
-        let mut stream =
-            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
-
-        match &this.state {
-            TlsState::Stream | TlsState::WriteShutdown => {
-                let prev = buf.remaining();
-
-                match stream.as_mut_pin().poll_read(cx, buf) {
-                    Poll::Ready(Ok(())) => {
-                        if prev == buf.remaining() || stream.eof {
-                            this.state.shutdown_read();
-                        }
-
-                        Poll::Ready(Ok(()))
-                    }
-                    Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::UnexpectedEof => {
-                        this.state.shutdown_read();
-                        Poll::Ready(Err(err))
-                    }
-                    output => output,
-                }
-            }
-            TlsState::ReadShutdown | TlsState::FullyShutdown => Poll::Ready(Ok(())),
-            #[cfg(feature = "early-data")]
-            s => unreachable!("server TLS can not hit this state: {:?}", s),
-        }
+        let data = ready!(self.as_mut().poll_fill_buf(cx))?;
+        let len = data.len().min(buf.remaining());
+        buf.put_slice(&data[..len]);
+        self.consume(len);
+        Poll::Ready(Ok(()))
     }
 }
 


### PR DESCRIPTION
Now that https://github.com/rustls/rustls/pull/2303 is merged, we can make use of it to implement AsyncBufRead.

This also reimplements AsyncRead in terms of AsyncBufRead, which indirectly fixes #55.