### PR TITLE
Cargo: MSRV 1.70 -> 1.71

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -95,6 +95,6 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: "1.70"
+          toolchain: "1.71"
 
       - run: cargo check --locked --lib --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 description = "Asynchronous TLS/SSL streams for Tokio using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.71"
 exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]


### PR DESCRIPTION
The upstream Rustls library updated its MSRV to 1.71 for 0.23.20+

Ref. https://github.com/rustls/rustls/pull/2220, https://github.com/rustls/rustls/issues/2239#issuecomment-2498638066