### PR TITLE
feat: add access to underlying config

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,8 +155,8 @@ impl TlsConnector {
     }
 
     /// Get a read-only reference to underlying config
-    pub fn config(&self) -> Arc<ClientConfig> {
-        self.inner.clone()
+    pub fn config(&self) -> &Arc<ClientConfig> {
+        &self.inner
     }
 }
 
@@ -195,8 +195,8 @@ impl TlsAcceptor {
     }
 
     /// Get a read-only reference to underlying config
-    pub fn config(&self) -> Arc<ServerConfig> {
-        self.inner.clone()
+    pub fn config(&self) -> &Arc<ServerConfig> {
+        &self.inner
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -153,6 +153,11 @@ impl TlsConnector {
             session,
         }))
     }
+
+    /// Get a read-only reference to underlying config
+    pub fn config(&self) -> Arc<ClientConfig> {
+        self.inner.clone()
+    }
 }
 
 impl TlsAcceptor {
@@ -187,6 +192,11 @@ impl TlsAcceptor {
             io: stream,
             state: TlsState::Stream,
         }))
+    }
+
+    /// Get a read-only reference to underlying config
+    pub fn config(&self) -> Arc<ServerConfig> {
+        self.inner.clone()
     }
 }
 


### PR DESCRIPTION
This patch exposes underlying `ClientConfig` and `ServerConfig` for `TlsConnector` and `TlsAcceptor`. My use-case is I'm use `TlsConnector` as API but I have to check if it's correctly configured.