### PR TITLE
Clarify how to run the example server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/*.rs.bk
 .DS_Store
 /.idea
+/certs

--- a/README.md
+++ b/README.md
@@ -47,7 +47,15 @@ cargo run --example client -- hsts.badssl.com
 See [examples/server.rs](examples/server.rs). You can run it with:
 
 ```sh
-cargo run --example server -- 127.0.0.1:8000 --cert mycert.der --key mykey.der
+cargo run --example server -- 127.0.0.1:8000 --cert certs/cert.pem --key certs/cert.key.pem
+```
+
+If you don't have a certificate and key, you can generate a random key and
+self-signed certificate for testing with:
+
+```sh
+cargo install --locked rustls-cert-gen
+rustls-cert-gen --output certs/ --san localhost
 ```
 
 ### License & Origin


### PR DESCRIPTION
When I was trying to test out the server example, at first I was thrown off because `README.md` mentioned `.der` files (a binary format). After looking at the code again, it turned out the solution was to use `.pem` files instead (text format). To make it easier, I've also included instructions for how to create certificate and key pem files with `openssl` commands.
