### PR TITLE
fix: handshake does not fully flush writes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,6 +149,8 @@ impl TlsConnector {
                 TlsState::Stream
             },
 
+            need_flush: false,
+
             #[cfg(feature = "early-data")]
             early_waker: None,
 
@@ -193,6 +195,7 @@ impl TlsAcceptor {
             session,
             io: stream,
             state: TlsState::Stream,
+            need_flush: false,
         }))
     }
 
@@ -363,6 +366,7 @@ where
             session: conn,
             io: self.io,
             state: TlsState::Stream,
+            need_flush: false,
         }))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -18,6 +18,7 @@ pub struct TlsStream<IO> {
     pub(crate) io: IO,
     pub(crate) session: ServerConnection,
     pub(crate) state: TlsState,
+    pub(crate) need_flush: bool,
 }
 
 impl<IO> TlsStream<IO> {
@@ -47,8 +48,13 @@ impl<IO> IoSession for TlsStream<IO> {
     }
 
     #[inline]
-    fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session) {
-        (&mut self.state, &mut self.io, &mut self.session)
+    fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session, &mut bool) {
+        (
+            &mut self.state,
+            &mut self.io,
+            &mut self.session,
+            &mut self.need_flush,
+        )
     }
 
     #[inline]

--- a/tests/early-data.rs
+++ b/tests/early-data.rs
@@ -10,7 +10,7 @@ use std::thread;
 use futures_util::{future::Future, ready};
 use rustls::pki_types::ServerName;
 use rustls::{self, ClientConfig, ServerConnection, Stream};
-use tokio::io::{AsyncRead, AsyncReadExt, AsyncWriteExt, ReadBuf};
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, ReadBuf};
 use tokio::net::TcpStream;
 use tokio_rustls::client::TlsStream;
 use tokio_rustls::TlsConnector;
@@ -35,14 +35,15 @@ impl<T: AsyncRead + Unpin> Future for Read1<T> {
     }
 }
 
-async fn send(
+async fn send<S: AsyncRead + AsyncWrite + Unpin>(
     config: Arc<ClientConfig>,
     addr: SocketAddr,
+    wrapper: impl Fn(TcpStream) -> S,
     data: &[u8],
     vectored: bool,
-) -> io::Result<(TlsStream<TcpStream>, Vec<u8>)> {
+) -> io::Result<(TlsStream<S>, Vec<u8>)> {
     let connector = TlsConnector::from(config).early_data(true);
-    let stream = TcpStream::connect(&addr).await?;
+    let stream = wrapper(TcpStream::connect(&addr).await?);
     let domain = ServerName::try_from("foobar.com").unwrap();
 
     let mut stream = connector.connect(domain, stream).await?;
@@ -58,15 +59,23 @@ async fn send(
 
 #[tokio::test]
 async fn test_0rtt() -> io::Result<()> {
-    test_0rtt_impl(false).await
+    test_0rtt_impl(|s| s, false).await
 }
 
 #[tokio::test]
 async fn test_0rtt_vectored() -> io::Result<()> {
-    test_0rtt_impl(true).await
+    test_0rtt_impl(|s| s, true).await
 }
 
-async fn test_0rtt_impl(vectored: bool) -> io::Result<()> {
+#[tokio::test]
+async fn test_0rtt_vectored_flush_pending() -> io::Result<()> {
+    test_0rtt_impl(utils::FlushWrapper::new, false).await
+}
+
+async fn test_0rtt_impl<S: AsyncRead + AsyncWrite + Unpin>(
+    wrapper: impl Fn(TcpStream) -> S,
+    vectored: bool,
+) -> io::Result<()> {
     let (mut server, mut client) = utils::make_configs();
     server.max_early_data_size = 8192;
     let server = Arc::new(server);
@@ -108,11 +117,11 @@ async fn test_0rtt_impl(vectored: bool) -> io::Result<()> {
     let client = Arc::new(client);
     let addr = SocketAddr::from(([127, 0, 0, 1], server_port));
 
-    let (io, buf) = send(client.clone(), addr, b"hello", vectored).await?;
+    let (io, buf) = send(client.clone(), addr, &wrapper, b"hello", vectored).await?;
     assert!(!io.get_ref().1.is_early_data_accepted());
     assert_eq!("LATE:hello", String::from_utf8_lossy(&buf));
 
-    let (io, buf) = send(client, addr, b"world!", vectored).await?;
+    let (io, buf) = send(client, addr, wrapper, b"world!", vectored).await?;
     assert!(io.get_ref().1.is_early_data_accepted());
     assert_eq!("EARLY:world!LATE:", String::from_utf8_lossy(&buf));
 

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,11 +1,14 @@
 mod utils {
+    use std::collections::VecDeque;
     use std::io::IoSlice;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
 
     use rustls::{
         pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
         ClientConfig, RootCertStore, ServerConfig,
     };
-    use tokio::io::{self, AsyncWrite, AsyncWriteExt};
+    use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 
     #[allow(dead_code)]
     pub(crate) fn make_configs() -> (ServerConfig, ClientConfig) {
@@ -66,4 +69,86 @@ mod utils {
 
     #[allow(dead_code)]
     pub(crate) const TEST_SERVER_DOMAIN: &str = "foobar.com";
+
+    /// An IO wrapper that never flushes when writing, and always returns pending on first flush.
+    ///
+    /// This is used to test that rustls always flushes to completion during handshake.
+    pub(crate) struct FlushWrapper<S> {
+        stream: S,
+        buf: VecDeque<Vec<u8>>,
+        queued: Vec<u8>,
+    }
+
+    impl<S> FlushWrapper<S> {
+        #[allow(dead_code)]
+        pub(crate) fn new(stream: S) -> Self {
+            FlushWrapper {
+                stream,
+                buf: VecDeque::new(),
+                queued: Vec::new(),
+            }
+        }
+    }
+
+    impl<S: AsyncRead + Unpin> AsyncRead for FlushWrapper<S> {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut tokio::io::ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            Pin::new(&mut self.get_mut().stream).poll_read(cx, buf)
+        }
+    }
+
+    impl<S: AsyncWrite + Unpin> FlushWrapper<S> {
+        fn poll_flush_inner<F>(
+            &mut self,
+            cx: &mut Context<'_>,
+            flush_inner: F,
+        ) -> Poll<Result<(), io::Error>>
+        where
+            F: FnOnce(Pin<&mut S>, &mut Context<'_>) -> Poll<Result<(), io::Error>>,
+        {
+            loop {
+                let stream = Pin::new(&mut self.stream);
+                if !self.queued.is_empty() {
+                    // write out the queued data
+                    let n = std::task::ready!(stream.poll_write(cx, &self.queued))?;
+                    self.queued = self.queued[n..].to_vec();
+                } else if let Some(buf) = self.buf.pop_front() {
+                    // queue the flush, but don't trigger the write immediately.
+                    self.queued = buf;
+                    cx.waker().wake_by_ref();
+                    return Poll::Pending;
+                } else {
+                    // nothing more to flush to the inner stream, flush the inner stream instead.
+                    return flush_inner(stream, cx);
+                }
+            }
+        }
+    }
+
+    impl<S: AsyncWrite + Unpin> AsyncWrite for FlushWrapper<S> {
+        fn poll_write(
+            self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize, io::Error>> {
+            self.get_mut().buf.push_back(buf.to_vec());
+            Poll::Ready(Ok(buf.len()))
+        }
+
+        fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+            self.get_mut()
+                .poll_flush_inner(cx, |s, cx| s.poll_flush(cx))
+        }
+
+        fn poll_shutdown(
+            self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+        ) -> Poll<Result<(), io::Error>> {
+            self.get_mut()
+                .poll_flush_inner(cx, |s, cx| s.poll_shutdown(cx))
+        }
+    }
 }


### PR DESCRIPTION
@almindor pointed out a potential issue with poll_flush within handshake. If write returns Ready, but flush returns Pending, it's guaranteed that the `handshake()` function returns and loses the `need_flush` state. If there's no more data to write, then it will never attempt to flush or write again.

Given the nature of TLS, it could be the client hello still needs flushing before a server hello would ever be readable.

This normally wouldn't be observable against a TcpStream, given that TcpStream has no flush impl.

The first commit creates a test that currently times out. The second commit introduces a potential fix which caches the `need_flush` state. ~~I'm not sure what to do about early-data handling.~~