### PR TITLE
fix: rustls feature is now called `log`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ aws_lc_rs = ["rustls/aws_lc_rs"]
 aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
 early-data = []
 fips = ["rustls/fips"]
-logging = ["rustls/logging"]
+logging = ["rustls/log"]
 ring = ["rustls/ring"]
 tls12 = ["rustls/tls12"]
 


### PR DESCRIPTION
see https://github.com/rustls/rustls/blob/main/rustls/Cargo.toml#L23

this feature was renamed in https://github.com/rustls/rustls/commit/192ab85a5c2c865b9cca9b2a8c987de33a102667, via https://github.com/rustls/rustls/pull/2549.

this updates the `logging` feature so that it now points to the new name of this feature.