### PR TITLE
Follow rustls@0.24 features changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,9 +648,8 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
+version = "0.24.0-dev.0"
+source = "git+https://github.com/rustls/rustls.git?rev=30f3753a70c3b138841675b6381c0b63a3005414#30f3753a70c3b138841675b6381c0b63a3005414"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -673,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,15 @@ rust-version = "1.71"
 exclude = ["/.github", "/examples", "/scripts"]
 
 [dependencies]
-rustls = { version = "0.23.27", default-features = false, features = ["std"] }
+rustls = { git = "https://github.com/rustls/rustls.git", rev = "30f3753a70c3b138841675b6381c0b63a3005414", default-features = false, features = ["std"] }
 tokio = "1.0"
 
 [features]
-default = ["logging", "tls12", "aws_lc_rs"]
-aws_lc_rs = ["rustls/aws_lc_rs"]
-aws-lc-rs = ["aws_lc_rs"] # Alias because Cargo features commonly use `-`
+default = ["log", "tls12"]
+aws-lc-rs = ["rustls/aws-lc-rs"]
 early-data = []
 fips = ["rustls/fips"]
-logging = ["rustls/logging"]
+log = ["rustls/log"]
 ring = ["rustls/ring"]
 tls12 = ["rustls/tls12"]
 


### PR DESCRIPTION
This follows changes in yet-unreleased `rustls@0.24` so they can be tracked and relied upon by other dependencies.
I've asked for an RC release at https://github.com/rustls/rustls/issues/2400#issuecomment-3157678869

Going farther than https://github.com/rustls/tokio-rustls/pull/118