### PR TITLE
server: expose transport from `StartHandshake`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -253,6 +253,12 @@ where
     }
 }
 
+impl<IO> AsRef<IO> for StartHandshake<IO> {
+    fn as_ref(&self) -> &IO {
+        &self.io
+    }
+}
+
 /// Future returned from `TlsAcceptor::accept` which will resolve
 /// once the accept handshake has finished.
 pub struct Accept<IO>(MidHandshake<TlsStream<IO>>);


### PR DESCRIPTION
This adds an `AsRef<IO>` implementation to the existing `StartHandshake` object, in order to allow introspecting the state of the underlying I/O transport.

For context and usecase, see https://github.com/rustls/tokio-rustls/issues/125.