### PR TITLE
server: allow splitting and reassembling a `StartHandshake`

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -205,6 +205,19 @@ impl<IO> StartHandshake<IO>
 where
     IO: AsyncRead + AsyncWrite + Unpin,
 {
+    /// Create a new object from an `IO` transport and prior TLS metadata.
+    pub fn from_parts(transport: IO, accepted: rustls::server::Accepted) -> Self {
+        Self {
+            accepted,
+            io: transport,
+        }
+    }
+
+    /// Consume this object and return the underlying components.
+    pub fn into_parts(self) -> (IO, rustls::server::Accepted) {
+        (self.io, self.accepted)
+    }
+
     pub fn client_hello(&self) -> rustls::server::ClientHello<'_> {
         self.accepted.client_hello()
     }


### PR DESCRIPTION
This adds two methods to the existing `StartHandshake` in order to allow splitting and reconstructing the underlying components.

For context and usecase, see https://github.com/rustls/tokio-rustls/issues/125.