### PR TITLE
Exclude bad test keys from the published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ description = "Asynchronous TLS/SSL streams for Tokio using Rustls."
 categories = ["asynchronous", "cryptography", "network-programming"]
 edition = "2021"
 rust-version = "1.71"
-exclude = ["/.github", "/examples", "/scripts"]
+exclude = ["/.github", "/examples", "/scripts", "/tests/"]
 
 [dependencies]
 rustls = { version = "0.23.27", default-features = false, features = ["std"] }


### PR DESCRIPTION
During a dependency review I noticed that tokio-rustls includes bad test keys in the binary pem format in the published packages. These files are not required for building tokio-rustls and make it harder to review the code.

This commit explicitly excludes these files from the published package. Before this change `cargo package` reported a size of 22 files, 137.1KiB (34.6KiB compressed). After this change it reports a size of 14 files, 110.6KiB (27.3KiB compressed), so this is only a rather minimal size reduction. Nevertheless given the current number of 17 million downloads per month that would result in a 118 GB/month traffic reduction for crates.io. For me personally the exclusion of the binary files is the more important outcome.
