### PR TITLE
Add tests for holding back alerts

### DIFF
--- a/tests/test.rs
+++ b/tests/test.rs
@@ -319,6 +319,77 @@ async fn lazy_config_acceptor_alert() {
 }
 
 #[tokio::test]
+async fn lazy_config_acceptor_return_http() {
+    let (mut cstream, sstream) = tokio::io::duplex(1024);
+
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        // This is write instead of write_all because of the short duplex size, which is necessarily
+        // symmetrical. We never finish writing because the LazyConfigAcceptor returns an error
+        let _ = cstream.write(b"not tls").await;
+        let mut buf = Vec::new();
+        cstream.read_to_end(&mut buf).await.unwrap();
+        tx.send(buf).unwrap();
+    });
+
+    let acceptor =
+        LazyConfigAcceptor::new(rustls::server::Acceptor::default(), sstream).send_alert(false);
+    tokio::pin!(acceptor);
+
+    let Ok(accept_result) = time::timeout(Duration::from_secs(3), acceptor.as_mut()).await else {
+        panic!("timeout");
+    };
+
+    assert!(accept_result.is_err());
+    let mut io = acceptor.take_io().unwrap();
+    io.write_all(b"HTTP/1.1 400 Invalid Input\r\n\r\n\r\nNot TLS\n")
+        .await
+        .unwrap();
+    io.shutdown().await.unwrap();
+
+    let Ok(Ok(received)) = time::timeout(Duration::from_secs(3), rx).await else {
+        panic!("failed to receive");
+    };
+
+    let recv = b"HTTP/1.1 400 Invalid Input\r\n\r\n\r\nNot TLS\n";
+    assert_eq!(received, recv)
+}
+
+#[tokio::test]
+async fn lazy_config_acceptor_manual_alert() {
+    let (mut cstream, sstream) = tokio::io::duplex(2);
+
+    let (tx, rx) = oneshot::channel();
+
+    tokio::spawn(async move {
+        // This is write instead of write_all because of the short duplex size, which is necessarily
+        // symmetrical. We never finish writing because the LazyConfigAcceptor returns an error
+        let _ = cstream.write(b"not tls").await;
+        let mut buf = Vec::new();
+        cstream.read_to_end(&mut buf).await.unwrap();
+        tx.send(buf).unwrap();
+    });
+
+    let acceptor =
+        LazyConfigAcceptor::new(rustls::server::Acceptor::default(), sstream).send_alert(false);
+    tokio::pin!(acceptor);
+
+    let Ok(accept_result) = time::timeout(Duration::from_secs(3), acceptor.as_mut()).await else {
+        panic!("timeout");
+    };
+
+    assert!(accept_result.is_err());
+    acceptor.write_alert().await.unwrap();
+    let Ok(Ok(received)) = time::timeout(Duration::from_secs(3), rx).await else {
+        panic!("failed to receive");
+    };
+
+    let fatal_alert_decode_error = b"\x15\x03\x03\x00\x02\x02\x32";
+    assert_eq!(received, fatal_alert_decode_error)
+}
+
+#[tokio::test]
 async fn handshake_flush_pending() -> io::Result<()> {
     pass_impl(utils::FlushWrapper::new, false).await
 }


### PR DESCRIPTION
This is a PR against a PR (https://github.com/rustls/tokio-rustls/pull/147).

* Adds tests for both cases: deciding to writing the alert, and deciding to not write the alert. Note: the reason one would decide to not write the alert would typically be some check if its HTTP (if so, send HTTP error) else send the original alert.
* In order to actually write the alert, one would have to implement their own SyncWriteAdapter (I think?), so I made a helper function to write the alert down.
* In the case of writing the alert, I found that the alert is actually not present; I fixed this by returning immediately once we set the alert. This is because:
   * We get error, so we set the alert, continue the loop.
   * We take the alert, then discard it since its not Sending().
   * We get an error in read_tls so we return.