### PR TITLE
Turn off tokio default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = ["/.github", "/examples", "/scripts", "/tests/"]
 
 [dependencies]
 rustls = { version = "0.23.27", default-features = false, features = ["std"] }
-tokio = "1.0"
+tokio = { version = "1.0", default-features = false }
 
 [features]
 default = ["logging", "tls12", "aws_lc_rs"]


### PR DESCRIPTION
tokio-rustls only uses a subset of tokio in order to compile the library. This turns off the default features of tokio to reduce compile times and avoid pulling in unnecessary dependencies.