### PR TITLE
Sync CI with more rustls ecosystem best practices

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+fmt-unstable = ["fmt", "--all", "--", "--config-path", ".rustfmt.unstable.toml"]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -120,3 +120,15 @@ jobs:
           toolchain: "1.75"
 
       - run: cargo check --locked --lib --all-features
+
+  semver:
+    name: Check semver compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Check semver
+        uses: obi1kenobi/cargo-semver-checks-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,6 +11,10 @@ on:
     - cron: "33 4 * * 5"
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,11 +63,12 @@ jobs:
         if: runner.os == 'Windows'
         uses: seanmiddleditch/gha-setup-ninja@v6
 
-
       - name: Test
         run: |
           cargo test --locked --all
           cargo test --locked -p tokio-rustls --features early-data --test early-data
+        env:
+          RUST_BACKTRACE: 1
 
   lints:
     name: Lints

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,9 +5,11 @@ on:
     branches: ['main', 'rel-*', 'ci/*']
     tags:
       - '**'
-  pull_request: {}
+  pull_request:
+  merge_group:
   schedule:
     - cron: "33 4 * * 5"
+  workflow_dispatch:
 
 jobs:
   check:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -150,3 +150,26 @@ jobs:
 
       - name: Check semver
         uses: obi1kenobi/cargo-semver-checks-action@v2
+
+  check-external-types:
+    name: Validate external types appearing in public API
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2026-03-20
+          # ^ sync with https://github.com/awslabs/cargo-check-external-types/blob/main/rust-toolchain.toml
+
+      - name: Install cargo-check-external-types
+        uses: taiki-e/cache-cargo-install-action@v3
+        with:
+          tool: cargo-check-external-types
+
+      - name: run cargo-check-external-types
+        run: cargo check-external-types

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,12 +15,12 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  RUSTFLAGS: --deny warnings
+
 jobs:
   check:
     runs-on: ubuntu-latest
-
-    env:
-      RUSTFLAGS: "-D warnings"
 
     steps:
       - name: Checkout sources
@@ -40,9 +40,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, windows-latest]
         rust: [stable]
-
-    env:
-      RUSTFLAGS: "-D warnings"
 
     steps:
       - name: Checkout sources
@@ -88,7 +85,7 @@ jobs:
 
       - name: Run cargo clippy
         if: always()
-        run: cargo clippy --locked --all-features -- -D warnings
+        run: cargo clippy --locked --all-features
 
   msrv:
     name: MSRV

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches:
-    - main
-    - "*_dev"
+    branches: ['main', 'rel-*', 'ci/*']
+    tags:
+      - '**'
   pull_request: {}
   schedule:
     - cron: "33 4 * * 5"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -70,8 +70,8 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-  lints:
-    name: Lints
+  clippy:
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -82,14 +82,27 @@ jobs:
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt, clippy
-
-      - name: Run cargo fmt
-        run: cargo fmt --all --check
+          components: clippy
 
       - name: Run cargo clippy
-        if: always()
         run: cargo clippy --locked --all-features
+
+  rustfmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo +nightly fmt-unstable --check
 
   docs:
     name: Check for documentation errors

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -92,7 +92,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -127,7 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -142,7 +142,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 
@@ -169,7 +169,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           persist-credentials: false
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: ['main', 'rel-*', 'ci/*']

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -91,6 +91,24 @@ jobs:
         if: always()
         run: cargo clippy --locked --all-features
 
+  docs:
+    name: Check for documentation errors
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install rust toolchain
+        # use nightly to mirror docs.rs
+        uses: dtolnay/rust-toolchain@nightly
+
+      - name: cargo doc
+        run: cargo doc --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
   msrv:
     name: MSRV
     runs-on: ubuntu-latest

--- a/.rustfmt.unstable.toml
+++ b/.rustfmt.unstable.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+style_edition = "2024"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,3 +35,15 @@ lazy_static = "1.1"
 rcgen = { version = "0.14", features = ["pem"] }
 tokio = { version = "1.0", features = ["full"] }
 webpki-roots = "1"
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+    # ---
+    "rustls",
+    "rustls::*",
+    "rustls_pki_types",
+    "rustls_pki_types::*",
+    "tokio::io::async_read::AsyncRead",
+    "tokio::io::async_buf_read::AsyncBufRead",
+    "tokio::io::async_write::AsyncWrite",
+]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -7,9 +7,9 @@ use std::sync::Arc;
 use argh::FromArgs;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, ServerName};
-use tokio::io::{copy, split, stdin as tokio_stdin, stdout as tokio_stdout, AsyncWriteExt};
+use tokio::io::{AsyncWriteExt, copy, split, stdin as tokio_stdin, stdout as tokio_stdout};
 use tokio::net::TcpStream;
-use tokio_rustls::{rustls, TlsConnector};
+use tokio_rustls::{TlsConnector, rustls};
 
 /// Tokio Rustls client example
 #[derive(FromArgs)]

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,16 +1,15 @@
+use std::error::Error as StdError;
 use std::io;
 use std::net::ToSocketAddrs;
 use std::path::PathBuf;
-
-use std::error::Error as StdError;
 use std::sync::Arc;
 
 use argh::FromArgs;
 use rustls::pki_types::pem::PemObject;
 use rustls::pki_types::{CertificateDer, PrivateKeyDer};
-use tokio::io::{copy, sink, split, AsyncWriteExt};
+use tokio::io::{AsyncWriteExt, copy, sink, split};
 use tokio::net::TcpListener;
-use tokio_rustls::{rustls, TlsAcceptor};
+use tokio_rustls::{TlsAcceptor, rustls};
 
 /// Tokio Rustls server example
 #[derive(FromArgs)]

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,18 +1,17 @@
 use std::future::Future;
+use std::io::{self, BufRead as _};
 #[cfg(unix)]
 use std::os::unix::io::{AsRawFd, RawFd};
 #[cfg(windows)]
 use std::os::windows::io::{AsRawSocket, RawSocket};
 use std::pin::Pin;
+use std::sync::Arc;
 #[cfg(feature = "early-data")]
 use std::task::Waker;
 use std::task::{Context, Poll};
-use std::{
-    io::{self, BufRead as _},
-    sync::Arc,
-};
 
-use rustls::{pki_types::ServerName, ClientConfig, ClientConnection};
+use rustls::pki_types::ServerName;
+use rustls::{ClientConfig, ClientConnection};
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 
 use crate::common::{IoSession, MidHandshake, Stream, TlsState};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,6 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 pub use rustls;
-
 use rustls::CommonState;
 use tokio::io::{AsyncBufRead, AsyncRead, AsyncWrite, ReadBuf};
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -147,7 +147,7 @@ where
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::Other,
                         "acceptor cannot be polled after acceptance",
-                    )))
+                    )));
                 }
             };
 
@@ -158,7 +158,7 @@ where
                         return Poll::Pending;
                     }
                     Ok(0) | Err(_) => {
-                        return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidData, err)))
+                        return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidData, err)));
                     }
                     Ok(_) => {
                         this.alert = Some((err, alert));

--- a/tests/badssl.rs
+++ b/tests/badssl.rs
@@ -4,12 +4,12 @@ use std::io;
 use std::net::ToSocketAddrs;
 use std::sync::Arc;
 
-use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
+use rustls::pki_types::ServerName;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio_rustls::client::TlsStream;
 use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream;
 
 async fn get(
     config: Arc<ClientConfig>,

--- a/tests/certs/main.rs
+++ b/tests/certs/main.rs
@@ -2,12 +2,13 @@
 //! Run with `cargo test -- --ignored` when test certificates need updating.
 //! Suitable for test certificates only. Not a production CA ;-)
 
+use std::fs::File;
+use std::io::Write;
+
 use rcgen::{
     BasicConstraints, CertificateParams, DistinguishedName, DnType, ExtendedKeyUsagePurpose, IsCa,
     Issuer, KeyPair, KeyUsagePurpose,
 };
-use std::fs::File;
-use std::io::Write;
 
 #[test]
 #[ignore]

--- a/tests/early-data.rs
+++ b/tests/early-data.rs
@@ -9,8 +9,8 @@ use rustls::pki_types::ServerName;
 use rustls::{self, ClientConfig, ServerConnection, Stream};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
-use tokio_rustls::client::TlsStream;
 use tokio_rustls::TlsConnector;
+use tokio_rustls::client::TlsStream;
 
 async fn send<S: AsyncRead + AsyncWrite + Unpin>(
     config: Arc<ClientConfig>,
@@ -59,35 +59,37 @@ async fn test_0rtt_impl<S: AsyncRead + AsyncWrite + Unpin>(
 
     let listener = TcpListener::bind("127.0.0.1:0")?;
     let server_port = listener.local_addr().unwrap().port();
-    thread::spawn(move || loop {
-        let (mut sock, _addr) = listener.accept().unwrap();
+    thread::spawn(move || {
+        loop {
+            let (mut sock, _addr) = listener.accept().unwrap();
 
-        let server = Arc::clone(&server);
-        thread::spawn(move || {
-            let mut conn = ServerConnection::new(server).unwrap();
-            conn.complete_io(&mut sock).unwrap();
+            let server = Arc::clone(&server);
+            thread::spawn(move || {
+                let mut conn = ServerConnection::new(server).unwrap();
+                conn.complete_io(&mut sock).unwrap();
 
-            if let Some(mut early_data) = conn.early_data() {
-                let mut buf = Vec::new();
-                early_data.read_to_end(&mut buf).unwrap();
-                let mut stream = Stream::new(&mut conn, &mut sock);
-                stream.write_all(b"EARLY:").unwrap();
-                stream.write_all(&buf).unwrap();
-            }
-
-            let mut stream = Stream::new(&mut conn, &mut sock);
-            stream.write_all(b"LATE:").unwrap();
-            loop {
-                let mut buf = [0; 1024];
-                let n = stream.read(&mut buf).unwrap();
-                if n == 0 {
-                    conn.send_close_notify();
-                    conn.complete_io(&mut sock).unwrap();
-                    break;
+                if let Some(mut early_data) = conn.early_data() {
+                    let mut buf = Vec::new();
+                    early_data.read_to_end(&mut buf).unwrap();
+                    let mut stream = Stream::new(&mut conn, &mut sock);
+                    stream.write_all(b"EARLY:").unwrap();
+                    stream.write_all(&buf).unwrap();
                 }
-                stream.write_all(&buf[..n]).unwrap();
-            }
-        });
+
+                let mut stream = Stream::new(&mut conn, &mut sock);
+                stream.write_all(b"LATE:").unwrap();
+                loop {
+                    let mut buf = [0; 1024];
+                    let n = stream.read(&mut buf).unwrap();
+                    if n == 0 {
+                        conn.send_close_notify();
+                        conn.complete_io(&mut sock).unwrap();
+                        break;
+                    }
+                    stream.write_all(&buf[..n]).unwrap();
+                }
+            });
+        }
     });
 
     client.enable_early_data = true;

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -2,16 +2,16 @@
 
 use std::io::{Cursor, ErrorKind};
 use std::net::SocketAddr;
-use std::sync::mpsc::channel;
 use std::sync::Arc;
+use std::sync::mpsc::channel;
 use std::time::Duration;
 use std::{io, thread};
 
 use futures_util::future::TryFutureExt;
 use lazy_static::lazy_static;
-use rustls::pki_types::ServerName;
 use rustls::ClientConfig;
-use tokio::io::{copy, split, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+use rustls::pki_types::ServerName;
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, copy, split};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::oneshot;
 use tokio::{runtime, time};

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -4,10 +4,9 @@ mod utils {
     use std::pin::Pin;
     use std::task::{Context, Poll};
 
-    use rustls::{
-        pki_types::{pem::PemObject, CertificateDer, PrivateKeyDer},
-        ClientConfig, RootCertStore, ServerConfig,
-    };
+    use rustls::pki_types::pem::PemObject;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+    use rustls::{ClientConfig, RootCertStore, ServerConfig};
     use tokio::io::{self, AsyncRead, AsyncWrite, AsyncWriteExt};
 
     #[allow(dead_code)]


### PR DESCRIPTION
Synchronizes on some CI changes we've made in most other repos. Notably also brings in the formatting bits from https://github.com/rustls/webpki/pull/503