### PR TITLE
return more data at once from TlsStream::poll_read

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -337,20 +337,22 @@ where
     ) -> Poll<io::Result<()>> {
         let data = ready!(self.as_mut().poll_fill_buf(cx))?;
         let len = data.len().min(buf.remaining());
-        if len > 0 {
+        if len == 0 {
+            return Poll::Ready(Ok(()));
+        }
+        buf.put_slice(&data[..len]);
+        self.as_mut().consume(len);
+
+        while buf.remaining() > 0 {
+            let data = match self.as_mut().poll_fill_buf(cx) {
+                Poll::Ready(Ok([])) => break,
+                Poll::Ready(Ok(data)) => data,
+                Poll::Ready(Err(_)) => break, // non-transient error gets re-emitted next poll
+                Poll::Pending => break,
+            };
+            let len = Ord::min(data.len(), buf.remaining());
             buf.put_slice(&data[..len]);
             self.as_mut().consume(len);
-            while buf.remaining() > 0 {
-                let data = match self.as_mut().poll_fill_buf(cx) {
-                    Poll::Ready(Ok([])) => break,
-                    Poll::Ready(Ok(data)) => data,
-                    Poll::Ready(Err(_)) => break, // non-transient error gets re-emitted next poll
-                    Poll::Pending => break,
-                };
-                let len = data.len().min(buf.remaining());
-                buf.put_slice(&data[..len]);
-                self.as_mut().consume(len);
-            }
         }
         Poll::Ready(Ok(()))
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -337,8 +337,21 @@ where
     ) -> Poll<io::Result<()>> {
         let data = ready!(self.as_mut().poll_fill_buf(cx))?;
         let len = data.len().min(buf.remaining());
-        buf.put_slice(&data[..len]);
-        self.consume(len);
+        if len > 0 {
+            buf.put_slice(&data[..len]);
+            self.as_mut().consume(len);
+            while buf.remaining() > 0 {
+                let data = match self.as_mut().poll_fill_buf(cx) {
+                    Poll::Ready(Ok([])) => break,
+                    Poll::Ready(Ok(data)) => data,
+                    Poll::Ready(Err(_)) => break, // non-transient error gets re-emitted next poll
+                    Poll::Pending => break,
+                };
+                let len = data.len().min(buf.remaining());
+                buf.put_slice(&data[..len]);
+                self.as_mut().consume(len);
+            }
+        }
         Poll::Ready(Ok(()))
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -421,8 +421,23 @@ where
     ) -> Poll<io::Result<()>> {
         let data = ready!(self.as_mut().poll_fill_buf(cx))?;
         let len = data.len().min(buf.remaining());
+        if len == 0 {
+            return Poll::Ready(Ok(()));
+        }
         buf.put_slice(&data[..len]);
-        self.consume(len);
+        self.as_mut().consume(len);
+
+        while buf.remaining() > 0 {
+            let data = match self.as_mut().poll_fill_buf(cx) {
+                Poll::Ready(Ok([])) => break,
+                Poll::Ready(Ok(data)) => data,
+                Poll::Ready(Err(_)) => break, // non-transient error gets re-emitted next poll
+                Poll::Pending => break,
+            };
+            let len = Ord::min(data.len(), buf.remaining());
+            buf.put_slice(&data[..len]);
+            self.as_mut().consume(len);
+        }
         Poll::Ready(Ok(()))
     }
 }


### PR DESCRIPTION
When using Hyper with tokio-rustls, and streaming a response body, hyper only emits blocks of 16k (a single TLS record), even when hyper uses a larger receive buffer. This causes more wake-ups for hyper callers, and generally more work inside hyper itself. 

This PR makes it so TlsStream::poll_read tries to return more data at once, which measurably improves Hyper's performance over TLS streams. 

I assume there is a similar gain on the server side with requests that have a large body (instead of response having a body for client), though i haven't attempted to measure or fix that yet.

very simple (but noisy) bench setup:
running a slightly simplified version of [this example](https://github.com/rustls/hyper-rustls/blob/main/examples/client.rs) (commenting out `to_bytes()` and actual printing of the body, to make the gain more visible), and running `perf stat ./target/release/examples/client https://proof.ovh.net/files/1Gb.dat` (download 1GiB from a remote server), i get
```
cpu-cycles:u
before: 3.6B
after: 2.7B

task-clock:u
before: 11.7s
after: 7.3s
```

While this could also be a change in hyper to call poll_read() until it returns Pending, i think other consumers of rustls could have the same inefficiency, and this is better handled at that level.